### PR TITLE
重做新闻模块的后端接口

### DIFF
--- a/frontend/pages/news_index/news_index.vue
+++ b/frontend/pages/news_index/news_index.vue
@@ -96,7 +96,97 @@
 	      isRefreshing: false, // 用于显示正在更新的状态
 	    };
 	  },
+	  async created() {
+	    // 在组件创建时调用后端获取数据
+	    await this.fetchData();
+	  },
 	  methods: {
+		async fetchData() {
+		  try {
+		    // 模拟从后端获取数据
+		    // 可以将此部分替换为实际的后端 API 调用，例如通过 axios:
+		    // const response = await axios.get('your-api-endpoint');
+		    
+		    // 假设从后端获取的数据如下：
+		    this.videoData = [{
+				id: 1,
+		    	form: 'news',
+		        newsSrc: 'http://vjs.zencdn.net/v/oceans.mp4',
+				imgsSrc: '',
+				tabs: ['环境保护','环保要闻'],
+				time: '2024-4-17',
+		    	newsName: '图文|后端连接测试',
+		        authorName: 'user_test',
+		        authorAvatar: '',
+		        newsinfo: '测试测试测试测试测试', 
+		    	newsbody: '9月17日，国际氢能联盟与麦肯锡联合发布《氢能洞察2024》，分析了全球氢能行业在过去一年的重要进展。该报告显示，全球氢能项目投资显著增长，氢能在清洁能源转型中扮演了重要角色。',
+		        likeCount: 1001,
+		        shareCount: 37,
+		        favoriteCount: 897,
+		        followCount: 189,
+		    	type: 'main'
+		      },
+		    {
+			  id: 2,
+		      form: 'news',
+		      newsSrc: 'http://vjs.zencdn.net/v/oceans.mp4',
+			  imgsSrc: '',
+			  tabs: ['公益事业'],
+			  time: '2024-5-17',
+		      newsName: '呱唧呱唧|前端新闻系统大更新',
+		      authorName: '中野梓',
+		      authorAvatar: '',
+		      newsinfo: '测试测试测试测试测试', 
+		      newsbody: '',
+		      likeCount: 1001,
+		      shareCount: 37,
+		      favoriteCount: 897,
+		      followCount: 189,
+		      type: 'main'
+		    }];
+			this.allnewsItems = [];
+			this.videoData.forEach(video => this.convertVideoToItems(video));
+		  } catch (error) {
+		    console.error('Error fetching data:', error);
+		  }
+		},
+		convertVideoToItems(video) {
+		  if (video.type === 'main') {
+			if(video.form === 'web') {
+				this.allNewsItems.push({
+				  id: video.id,
+				  link: video.newsSrc,
+				  image: '',
+				  title: video.newsName,
+				  description: video.tabs.join(' | ') + ' | '+ video.time,
+				  info: '阅读量: ' + video.followCount + ' | 点赞量: ' + video.likeCount,
+				  form: video.form,
+				});
+			}
+			else if(video.form === 'news') {
+				this.allNewsItems.push({
+				  id: video.id,
+				  link: 'news_detail',
+				  image: '',
+				  title: video.newsName,
+				  description: video.tabs.join(' | ') + ' | '+ video.time,
+				  info: '阅读量: ' + video.followCount + ' | 点赞量: ' + video.likeCount,
+				  form: video.form,
+				});
+			}
+			else if(video.form === 'video') {
+				this.allNewsItems.push({
+				  id: video.id,
+				  link: 'video_detail',
+				  image: '',
+				  title: video.newsName,
+				  description: video.tabs.join(' | ') + ' | '+ video.time,
+				  info: '阅读量: ' + video.followCount + ' | 点赞量: ' + video.likeCount,
+				  form: video.form,
+				});
+			}
+		  }
+		},
 	    // 控制新闻分类的显示
 	    showSection(section) {
 	      this.selectedSection = section; // 更新选中的分类

--- a/frontend/pagesNews/news_detail/news_detail.vue
+++ b/frontend/pagesNews/news_detail/news_detail.vue
@@ -11,15 +11,19 @@
       <view class="main-content">
         <view class="news-content">
           <view class="news-title">{{ webTitle }}</view>
+		  <view class="author-header">
+		  	<view class="author-avatar"></view>
+		    <text class="author-username">{{newsData[0].authorName}}</text>
+		  </view>
           <view class="news-body">
-            9月17日，国际氢能联盟与麦肯锡联合发布《氢能洞察2024》，分析了全球氢能行业在过去一年的重要进展。该报告显示，全球氢能项目投资显著增长，氢能在清洁能源转型中扮演了重要角色。
+            {{newsData[0].newsbody}}
           </view>
 
           <!-- Interaction Buttons - Merged into News Content -->
           <view class="inline-interaction-buttons">
-            <button @click="toggleInteraction('like')">👍 {{ likeText }}</button>
-            <button @click="toggleInteraction('favorite')">⭐ {{ favoriteText }}</button>
-            <button @click="toggleInteraction('share')">🔄 {{ shareText }}</button>
+            <button @click="toggleInteraction('like')">👍 {{ newsData[0].likeCount }}</button>
+            <button @click="toggleInteraction('favorite')">⭐ {{ newsData[0].favoriteCount }}</button>
+            <button @click="toggleInteraction('share')">🔄 {{ newsData[0].shareCount}}</button>
           </view>
         </view>
 
@@ -67,7 +71,7 @@
         <view class="sidebar-header">相关推荐</view>
         <view v-for="(recommendation, index) in recommendations" :key="index" class="recommendation-item">
           <image :src="recommendation.image" mode="widthFix" />
-          <view class="recommendation-title">{{ recommendation.title }}</view>
+          <view class="recommendation-title" @click="goRecommend(recommendation.title, recommendation.form, recommendation.id)">{{ recommendation.title }}</view>
           <view class="recommendation-info">{{ recommendation.info }}</view>
         </view>
       </view>
@@ -81,6 +85,7 @@ export default {
   data() {
     return {
 	  webTitle: '',
+	  newsData: [],
       comments: [
         { text: "这篇文章非常有用！", liked: false, replies: [] },
       ],
@@ -90,24 +95,12 @@ export default {
       likeText: '点赞',
       favoriteText: '收藏',
       shareText: '分享',
-      recommendations: [
-        {
-          image: "",
-          title: "把自然讲给你听 | 什么是森林？",
-          info: "阅读量: 1234 | 点赞量: 456"
-        },
-        {
-          image: "",
-          title: "全球氢能发展最新动态",
-          info: "阅读量: 987 | 点赞量: 321"
-        },
-        {
-          image: "",
-          title: "如何做好垃圾分类",
-          info: "阅读量: 789 | 点赞量: 123"
-        }
-      ]
+      recommendations: []
     };
+  },
+  async created() {
+    // 在组件创建时调用后端获取数据
+    await this.fetchData();
   },
   onLoad(options) {
     if (options.title) {
@@ -115,16 +108,81 @@ export default {
     }
   },
   methods: {
+	async fetchData() {
+	    try {
+	      // 模拟从后端获取数据
+	      // 可以将此部分替换为实际的后端 API 调用，例如通过 axios:
+	      // const response = await axios.get('your-api-endpoint');
+	      
+	      // 假设从后端获取的数据如下：
+	      this.newsData = [{
+			id: 1,
+			form: 'news',
+	        newsSrc: 'http://vjs.zencdn.net/v/oceans.mp4',
+			imgsSrc: '',
+			tabs: ['环境保护','环保要闻'],
+			time: '2024-4-17',
+			newsName: '垃圾分类',
+	        authorName: 'user_test',
+	        authorAvatar: '',
+	        newsinfo: '测试测试测试测试测试', 
+			newsbody: '9月17日，国际氢能联盟与麦肯锡联合发布《氢能洞察2024》，分析了全球氢能行业在过去一年的重要进展。该报告显示，全球氢能项目投资显著增长，氢能在清洁能源转型中扮演了重要角色。',
+	        likeCount: 1001,
+	        shareCount: 37,
+	        favoriteCount: 897,
+	        followCount: 189,
+			type: 'main'
+	      },
+	  	{
+		  id: 2,
+		  form: 'news',
+	  	  newsSrc: 'http://vjs.zencdn.net/v/oceans.mp4',
+		  imgsSrc: '',
+		  tabs: ['环境保护','环保要闻'],
+		  time: '2024-4-17',
+	  	  newsName: '把自然讲给你听',
+	  	  authorName: '中野梓',
+	  	  authorAvatar: '',
+	  	  newsinfo: '测试测试测试测试测试', 
+		  newsbody: '',
+	  	  likeCount: 1001,
+	  	  shareCount: 37,
+	  	  favoriteCount: 897,
+	  	  followCount: 189,
+	  	  type: 'reco'
+	  	}];
+	  	this.recommendations = [
+	  	  
+	  	];
+	  	this.newsData.forEach(news => this.convertnewsToRecommendation(news));
+	    } catch (error) {
+	      console.error('Error fetching data:', error);
+	    }
+	  },
+	  convertnewsToRecommendation(news) {
+	    if (news.type === 'reco') {
+	      this.recommendations.push({
+			id: news.id,
+			src: news.newsSrc,
+	        image: '',
+	        title: news.authorName + ' | ' + news.newsName,
+	        info: '阅读量: ' + news.followCount + ' | 点赞量: ' + news.likeCount,
+			form: news.form,
+	      });
+	    }
+	  },
     goBack() {
       uni.navigateBack();
     },
     toggleInteraction(type) {
       if (type === 'like') {
-        this.likeText = this.likeText === '点赞' ? '已点赞' : '点赞';
+        this.newsData[0].likeCount++;
       } else if (type === 'favorite') {
-        this.favoriteText = this.favoriteText === '收藏' ? '已收藏' : '收藏';
+        this.newsData[0].favoriteCount++;
+      } else if (type === 'follow') {
+        this.newsData[0].followCount++;
       } else if (type === 'share') {
-        this.shareText = this.shareText === '分享' ? '已分享' : '分享';
+        this.newsData[0].shareCount++;
       }
     },
     toggleCommentLike(index) {
@@ -146,7 +204,28 @@ export default {
         this.comments.push({ text: this.newComment, liked: false, replies: [] });
         this.newComment = '';
       }
-    }
+    },
+	// 页面跳转方法
+	goRecommend(title, form, id) {
+	  setTimeout(() => {
+	    if (form === 'news') {
+	      // 图文页面跳转
+	      uni.navigateTo({
+	        url: `/pagesNews/news_detail/news_detail?title=${title}}`,
+	      });
+	    } else if(form === 'video'){
+	      // 视频页面跳转
+	      uni.navigateTo({
+	        url: `/pagesNews/video_detail/video_detail?title=${name}`,
+	      });
+	    }
+		else{
+			uni.navigateTo({
+			  url: `/pagesNews/web_detail/web_detail?url=${encodeURIComponent(id)}`,
+			});
+		}
+	  }, 100); // 延迟 100 毫秒
+	},
   }
 };
 </script>
@@ -360,6 +439,29 @@ body {
 .recommendation-info {
   font-size: 14px;
   color: #555;
+}
+/*author part form video_detail*/
+.author-avatar {
+  width: 50px;
+  height: 50px;
+  background-color: #ccc;
+  border-radius: 50%;
+  margin-bottom: 10px;
+}
+
+.author-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.author-header {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+.author-username {
+  font-weight: bold;
+  margin-right: 20px;
 }
 
 </style>

--- a/frontend/pagesNews/video_detail/video_detail.vue
+++ b/frontend/pagesNews/video_detail/video_detail.vue
@@ -14,10 +14,10 @@
     <view class="video-content">
       <video
         class="video-container"
-        :src="videoData[0].videoSrc"
+        :src="videoData[0].newsSrc"
         controls
         autoplay
-        id="video"
+        id=1
         @play="onPlay"
         @pause="onPause"
       >
@@ -43,7 +43,7 @@
             <text class="author-username">{{videoData[0].authorName}}</text>
           </view>
 		  <view class="video_content">
-			<view class="video_info"> {{videoData[0].videoinfo}}</view>
+			<view class="video_info"> {{videoData[0].newsinfo}}</view>
 		  </view>
           <view class="author-interactions">
             <button @click="toggleInteraction('like')">👍 {{videoData[0].likeCount}}</button>
@@ -59,7 +59,7 @@
         <view class="sidebar-header">相关推荐</view>
         <view v-for="(recommendation, index) in recommendations" :key="index" class="recommendation-item">
           <image :src="recommendation.image" mode="widthFix" />
-          <view class="recommendation-title">{{ recommendation.title }}</view>
+          <view class="recommendation-title" @click="goRecommend(recommendation.title, recommendation.form, recommendation.id)">{{ recommendation.title }}</view>
           <view class="recommendation-info">{{ recommendation.info }}</view>
         </view>
       </view>
@@ -139,29 +139,41 @@
             
             // 假设从后端获取的数据如下：
             this.videoData = [{
-              videoSrc: 'http://vjs.zencdn.net/v/oceans.mp4',
-			  videoName: '垃圾分类',
-              authorName: 'user_test',
+				        id: 1,
+            	  form: 'news',
+                newsSrc: 'http://vjs.zencdn.net/v/oceans.mp4',
+				        imgsSrc: '',
+				        tabs: ['环境保护','环保要闻'],
+				        time: '2024-4-17',
+            	  newsName: '垃圾分类',
+                authorName: 'user_test',
+                authorAvatar: '',
+                newsinfo: '测试测试测试测试测试', 
+            	  newsbody: '9月17日，国际氢能联盟与麦肯锡联合发布《氢能洞察2024》，分析了全球氢能行业在过去一年的重要进展。该报告显示，全球氢能项目投资显著增长，氢能在清洁能源转型中扮演了重要角色。',
+                likeCount: 1001,
+                shareCount: 37,
+                favoriteCount: 897,
+                followCount: 189,
+            	  type: 'main'
+              },
+            {
+			        id:2,
+              form: 'news',
+              newsSrc: 'http://vjs.zencdn.net/v/oceans.mp4',
+			        imgsSrc: '',
+			        tabs: ['环境保护','环保要闻'],
+			        time: '2024-4-17',
+              newsName: '把自然讲给你听',
+              authorName: '中野梓',
               authorAvatar: '',
-              videoinfo: '测试测试测试测试测试', 
+              newsinfo: '测试测试测试测试测试', 
+              newsbody: '',
               likeCount: 1001,
               shareCount: 37,
               favoriteCount: 897,
               followCount: 189,
-			  type: 'main'
-            },
-			{
-			  videoSrc: 'http://vjs.zencdn.net/v/oceans.mp4',
-			  videoName: '把自然讲给你听',
-			  authorName: '中野梓',
-			  authorAvatar: '',
-			  videoinfo: '测试测试测试测试测试', 
-			  likeCount: 1001,
-			  shareCount: 37,
-			  favoriteCount: 897,
-			  followCount: 189,
-			  type: 'reco'
-			}];
+              type: 'reco'
+            }];
 			this.recommendations = [
 			  
 			];
@@ -173,10 +185,12 @@
 		convertVideoToRecommendation(video) {
 		  if (video.type === 'reco') {
 		    this.recommendations.push({
-			  id: video.videoSrc,
+			  id: video.id,
+			  src: video.newsSrc,
 		      image: '',
-		      title: video.authorName + ' | ' + video.videoName,
-		      info: '阅读量: ' + video.followCount + ' | 点赞量: ' + video.likeCount
+		      title: video.authorName + ' | ' + video.newsName,
+		      info: '阅读量: ' + video.followCount + ' | 点赞量: ' + video.likeCount,
+			  form: video.form,
 		    });
 		  }
 		},
@@ -223,6 +237,26 @@
         onPause() {
           console.log('Video is paused');
         },
+		goRecommend(title, form, id) {
+		  setTimeout(() => {
+		    if (form === 'news') {
+		      // 图文页面跳转
+		      uni.navigateTo({
+		        url: `/pagesNews/news_detail/news_detail?title=${title}}`,
+		      });
+		    } else if(form === 'video'){
+		      // 视频页面跳转
+		      uni.navigateTo({
+		        url: `/pagesNews/video_detail/video_detail?title=${name}`,
+		      });
+		    }
+			else{
+				uni.navigateTo({
+				  url: `/pagesNews/web_detail/web_detail?url=${encodeURIComponent(id)}`,
+				});
+			}
+		  }, 100); // 延迟 100 毫秒
+		},
       },
     };
 </script>


### PR DESCRIPTION
新的后端接口请见飞书文档；优化了咨询页面的跳转链接